### PR TITLE
fix(ci): run Skript 2.14.2 and 2.15.2 tests with correct JDK

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,24 +4,28 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
+          distribution: temurin
           java-version: 21
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
       - name: Build with Gradle
-        run: ./gradlew shadow -Penv=TEST
+        run: ./gradlew shadowJar -Penv=TEST
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
@@ -29,12 +33,12 @@ jobs:
           name: plugin-jar
           path: build/libs/*.jar
 
-  test:
+  test-skript-2-14:
     runs-on: ubuntu-latest
     needs: build
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Download artifacts
         uses: actions/download-artifact@v4
@@ -42,14 +46,7 @@ jobs:
           name: plugin-jar
           path: extra-plugins/
 
-      - name: Run tests - latest
-        uses: SkriptLang/skript-test-action@v1.2
-        with:
-          run_vanilla_tests: false
-          test_script_directory: src/test/scripts
-          extra_plugins_directory: extra-plugins/
-
-      - name: Run tests - 2.14+
+      - name: Run tests on Skript 2.14.2
         uses: SkriptLang/skript-test-action@v1.2
         with:
           skript_repo_ref: 2.14.2
@@ -57,10 +54,68 @@ jobs:
           test_script_directory: src/test/scripts
           extra_plugins_directory: extra-plugins/
 
-      - name: Run tests - 2.15+
-        uses: SkriptLang/skript-test-action@v1.2
+  test-skript-2-15:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
         with:
-          skript_repo_ref: 2.15.2
-          run_vanilla_tests: false
-          test_script_directory: src/test/scripts
-          extra_plugins_directory: extra-plugins/
+          name: plugin-jar
+          path: extra-plugins/
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 25
+
+      - name: Run tests on Skript 2.15.2
+        env:
+          WORKSPACE: ${{ github.workspace }}
+        run: |
+          set -euo pipefail
+          SKRIPT_DIR=/tmp/skript
+          git clone --recurse-submodules https://github.com/SkriptLang/Skript.git "$SKRIPT_DIR"
+          cd "$SKRIPT_DIR"
+          git checkout -f 2.15.2
+          git submodule update --recursive
+
+          python3 << 'PY'
+          import json
+          import os
+          import shutil
+          from pathlib import Path
+
+          workspace = Path(os.environ["WORKSPACE"])
+          skript = Path("/tmp/skript")
+          tests_dir = skript / "src/test/skript/tests"
+          custom_dir = tests_dir / "custom"
+
+          for entry in list(tests_dir.iterdir()):
+              if entry.is_file():
+                  entry.unlink()
+              else:
+                  shutil.rmtree(entry)
+
+          shutil.copytree(workspace / "src/test/scripts", custom_dir)
+
+          extra_plugins = workspace / "extra-plugins"
+          if extra_plugins.exists():
+              env_dir = skript / "src/test/skript/environments"
+              for env_file in env_dir.glob("**/*.json"):
+                  environment = json.loads(env_file.read_text())
+                  resources = environment.setdefault("resources", [])
+                  for plugin in extra_plugins.iterdir():
+                      resources.append({
+                          "source": str(plugin.resolve()),
+                          "target": f"plugins/{plugin.name}",
+                      })
+                  env_file.write_text(json.dumps(environment))
+          PY
+
+          chmod +x gradlew
+          ./gradlew quickTest


### PR DESCRIPTION
Remove empty skript_repo_ref checkout, use skript-test-action on 2.14.2, and add a JDK 25 job for Skript 2.15.2 builds.